### PR TITLE
Add bioconductor dependencies to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: MIT License
 Encoding: UTF-8
 LazyData: true
 Depends: GenomicFeatures, Rsamtools, ggplot2, doParallel, foreach,grid,rtracklayer,GenomicAlignments,reshape2,Rcpp,RcppArmadillo, qvalue
+biocViews:
 RoxygenNote: 6.1.1
 LinkingTo: Rcpp, RcppArmadillo
 Imports: Guitar, stringr,vcfR, broom, DESeq2, ggsci


### PR DESCRIPTION
Resolves

```
> devtools::install_github("scottzijiezhang/MeRIPtools")
Downloading GitHub repo scottzijiezhang/MeRIPtools@HEAD
Skipping 7 packages not available: DESeq2, Guitar, qvalue, GenomicAlignments, rtracklayer, Rsamtools, GenomicFeatures
   checking for file ・tmp/RtmpnXJh6O/remotes3d56353959681/scottzijiezhang-MeRIPtools-626569a/DESCRIPTIO?  checking for file ・tmp/RtmpnXJh6O/remotes3d56353959681/scottzijiezhang-MeRIPtools-626569a/DESCRIPTION
q  preparing MeRIPtools
?  checking DESCRIPTION meta-information ...
q  cleaning src
q  checking for LF line-endings in source and make files and shell scripts
q  checking for empty or unneeded directories
   Omitted LazyData・from DESCRIPTION
   building MeRIPtools_0.2.1.tar.gz

Installing package into home/kelly-t/R/x86_64-pc-linux-gnu-library/4.1
(as lib is unspecified)
ERROR: dependency DESeq2・is not available for package MeRIPtools
```